### PR TITLE
The module /dos/http/apache_range_dos did not initialize the URI variable

### DIFF
--- a/modules/auxiliary/dos/http/apache_range_dos.rb
+++ b/modules/auxiliary/dos/http/apache_range_dos.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def conduct_dos
-    datastore['URI']
+    uri = datastore['URI']
     rhost = datastore['RHOST']
     ranges = ''
 


### PR DESCRIPTION
I'm fixing a bug that is explained in the issue #20436, in which the module /dos/http/apache_range_dos does not work due to not having the URI defined.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use dos/http/apache_range_dos`
- [ ] `set rhosts [IP address to attack]`
- [ ] `run`
- [ ] **Verify** the DoS attack is in action


Specific Examples:
* You need a machine that is vulnerable to the CVE-2011-3192 like the metasploitable2 (https://docs.rapid7.com/metasploit/metasploitable-2)